### PR TITLE
Remove Dependabot config and add merge queue CI support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: daily
-      time: "03:00"
-      timezone: Europe/Vienna
-    open-pull-requests-limit: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  merge_group:
   schedule:
     - cron: "49 9 * * 2"
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -6,6 +6,7 @@ on:
       - master
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 permissions: {}
 
@@ -14,6 +15,7 @@ jobs:
     # Skip fork PRs — secrets are unavailable for security reasons
     if: >-
       github.event_name == 'push' ||
+      github.event_name == 'merge_group' ||
       github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read


### PR DESCRIPTION
Remove .github/dependabot.yml and add merge_group trigger to build,
CodeQL, and Sonar workflows so required checks fire during GitHub
merge queue runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic dependency management and security update automation previously configured within repository configuration files
  * Extended continuous integration and deployment pipelines to support GitHub merge queue feature, enabling improved workflow execution during code merge operations across build verification, security analysis scanning, code quality checks, and integration processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->