### PR TITLE
test: add unit test infrastructure and initial test suite

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.autonomousapps.tasks.ProjectHealthTask
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+import org.gradle.buildconfiguration.tasks.UpdateDaemonJvm
 
 /*
  * Copyright (C) 2001-2002  Zaval Creative Engineering Group (http://www.zaval.org)
@@ -29,6 +30,10 @@ tasks.check {
 	dependsOn(tasks.withType(ProjectHealthTask::class.java))
 }
 
+tasks.named<UpdateDaemonJvm>("updateDaemonJvm") {
+	languageVersion = JavaLanguageVersion.of(21)
+}
+
 application {
 	mainClass = "org.zaval.tools.i18n.translator.JrcEditor"
 	mainModule = "jrc.editor.main"
@@ -56,6 +61,16 @@ dependencies {
 
 	runtimeOnly(libs.bundles.slf4j.runtime)
 	runtimeOnly(libs.commons.beanutils)
+
+	testImplementation(platform(libs.junit.bom))
+	testImplementation(libs.junit.jupiter.api)
+	testRuntimeOnly(libs.junit.jupiter.engine)
+	testImplementation(libs.mockito.core)
+	testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+tasks.test {
+	useJUnitPlatform()
 }
 
 sourceSets {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,8 @@
 commons-configuration = "2.15.0"
 commons-beanutils = "1.11.0"
 slf4j = "2.0.18"
+junit-bom = "5.14.4"
+mockito = "5.23.0"
 
 [libraries]
 commons-configuration = { module = "org.apache.commons:commons-configuration2", version.ref = "commons-configuration" }
@@ -9,6 +11,11 @@ commons-beanutils = { module = "commons-beanutils:commons-beanutils", version.re
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 jcl-over-slf4j = { module = "org.slf4j:jcl-over-slf4j", version.ref = "slf4j" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-bom" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 
 [bundles]
 slf4j-runtime = ["jcl-over-slf4j", "slf4j-simple"]

--- a/src/main/java/org/zaval/tools/i18n/translator/SrcGenerator.java
+++ b/src/main/java/org/zaval/tools/i18n/translator/SrcGenerator.java
@@ -108,9 +108,9 @@ class SrcGenerator {
 	}
 
 	private String baseName(String fn) {
-		int ind = fn.lastIndexOf('/');
-		fn = ind >= 0 ? fn.substring(ind + 1) : fn;
-		ind = fn.lastIndexOf('.');
-		return ind >= 0 ? fn.substring(0, ind) : fn;
+		int sep = Math.max(fn.lastIndexOf('/'), fn.lastIndexOf('\\'));
+		fn = sep >= 0 ? fn.substring(sep + 1) : fn;
+		int dot = fn.lastIndexOf('.');
+		return dot >= 0 ? fn.substring(0, dot) : fn;
 	}
 }

--- a/src/test/java/org/zaval/tools/i18n/translator/BundleItemTest.java
+++ b/src/test/java/org/zaval/tools/i18n/translator/BundleItemTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2001-2002  Zaval Creative Engineering Group (http://www.zaval.org)
+ * Copyright (C) 2026 Christoph Obexer <cobexer@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * (version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.zaval.tools.i18n.translator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class BundleItemTest {
+	@Test
+	void constructorSetsId() {
+		BundleItem item = new BundleItem("my.key");
+		assertEquals("my.key", item.getId());
+	}
+
+	@Test
+	void getTranslationReturnsNullForUnknownLanguage() {
+		BundleItem item = new BundleItem("key");
+		assertNull(item.getTranslation("en"));
+	}
+
+	@Test
+	void setAndGetTranslationRoundtrip() {
+		BundleItem item = new BundleItem("key");
+		item.setTranslation("en", "Hello");
+		item.setTranslation("de", "Hallo");
+		assertEquals("Hello", item.getTranslation("en"));
+		assertEquals("Hallo", item.getTranslation("de"));
+	}
+
+	@Test
+	void setTranslationOverwritesPreviousValue() {
+		BundleItem item = new BundleItem("key");
+		item.setTranslation("en", "Old");
+		item.setTranslation("en", "New");
+		assertEquals("New", item.getTranslation("en"));
+	}
+
+	@Test
+	void commentIsNullByDefault() {
+		BundleItem item = new BundleItem("key");
+		assertNull(item.getComment());
+	}
+
+	@Test
+	void setAndGetComment() {
+		BundleItem item = new BundleItem("key");
+		item.setComment("a comment");
+		assertEquals("a comment", item.getComment());
+	}
+
+	@Test
+	void getLanguagesReflectsSetTranslations() {
+		BundleItem item = new BundleItem("key");
+		item.setTranslation("en", "Hello");
+		item.setTranslation("fr", "Bonjour");
+		assertTrue(item.getLanguages().contains("en"));
+		assertTrue(item.getLanguages().contains("fr"));
+		assertEquals(2, item.getLanguages().size());
+	}
+
+	@Test
+	void getLanguagesIsEmptyWhenNoTranslationsSet() {
+		BundleItem item = new BundleItem("key");
+		assertTrue(item.getLanguages().isEmpty());
+	}
+}

--- a/src/test/java/org/zaval/tools/i18n/translator/BundleManagerTest.java
+++ b/src/test/java/org/zaval/tools/i18n/translator/BundleManagerTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2001-2002  Zaval Creative Engineering Group (http://www.zaval.org)
+ * Copyright (C) 2026 Christoph Obexer <cobexer@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * (version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.zaval.tools.i18n.translator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class BundleManagerTest {
+	private final BundleManager manager = new BundleManager();
+
+	@Test
+	void baseNameStripsDirectoryAndExtension() {
+		assertEquals("Messages", manager.baseName("/path/to/Messages.properties"));
+	}
+
+	@Test
+	void baseNameWithNoDirectory() {
+		assertEquals("Messages", manager.baseName("Messages.properties"));
+	}
+
+	@Test
+	void baseNameWithNoExtension() {
+		assertEquals("Messages", manager.baseName("Messages"));
+	}
+
+	@Test
+	void baseNameWithWindowsPath() {
+		assertEquals("Messages", manager.baseName("C:\\path\\to\\Messages.properties"));
+	}
+
+	@Test
+	void determineLanguageForBaseFileReturnsEn() {
+		assertEquals("en", manager.determineLanguage("Messages.properties"));
+	}
+
+	@Test
+	void determineLanguageForSingleSuffix() {
+		assertEquals("de", manager.determineLanguage("Messages_de.properties"));
+	}
+
+	@Test
+	void determineLanguageForCountrySuffix() {
+		assertEquals("de_DE", manager.determineLanguage("Messages_de_DE.properties"));
+	}
+
+	@Test
+	void replaceSubstitutesSingleOccurrence() {
+		assertEquals("a/b/c", manager.replace("a\\b\\c", "\\", "/"));
+	}
+
+	@Test
+	void replaceSubstitutesAllOccurrences() {
+		assertEquals("x-x-x", manager.replace("xaxax", "a", "-"));
+	}
+
+	@Test
+	void replaceReturnsOriginalWhenNoMatch() {
+		String original = "no match here";
+		assertEquals(original, manager.replace(original, "xyz", "ABC"));
+	}
+
+	@Test
+	void replaceHandlesEmptyString() {
+		assertEquals("", manager.replace("", "a", "b"));
+	}
+
+	@Test
+	void appendResourceParsesPropertiesFromStream() throws IOException {
+		String content = "greeting=Hello\nfarewell=Goodbye\n";
+		ByteArrayInputStream stream = new ByteArrayInputStream(content.getBytes(StandardCharsets.ISO_8859_1));
+		manager.appendResource(stream, "en");
+
+		BundleSet bundle = manager.getBundle();
+		assertNotNull(bundle.getItem("greeting"));
+		assertEquals("Hello", bundle.getItem("greeting").getTranslation("en"));
+		assertEquals("Goodbye", bundle.getItem("farewell").getTranslation("en"));
+	}
+
+	@Test
+	void appendResourceIgnoresEmptyLines() throws IOException {
+		String content = "key1=value1\n\nkey2=value2\n";
+		manager.appendResource(new ByteArrayInputStream(content.getBytes(StandardCharsets.ISO_8859_1)), "en");
+		assertEquals(2, manager.getBundle().getItemCount());
+	}
+
+	@Test
+	void appendResourceParsesComments() throws IOException {
+		String content = "#a comment\nkey=value\n";
+		manager.appendResource(new ByteArrayInputStream(content.getBytes(StandardCharsets.ISO_8859_1)), "en");
+		assertEquals("a comment", manager.getBundle().getItem("key").getComment());
+	}
+
+	@Test
+	void appendResourceHandlesEmptyValue() throws IOException {
+		String content = "key=\n";
+		manager.appendResource(new ByteArrayInputStream(content.getBytes(StandardCharsets.ISO_8859_1)), "en");
+		assertEquals("", manager.getBundle().getItem("key").getTranslation("en"));
+	}
+
+	@Test
+	void storeWritesPropertiesFile(@TempDir Path tmpDir) throws IOException {
+		manager.appendResource(new ByteArrayInputStream("greeting=Hello\n".getBytes(StandardCharsets.ISO_8859_1)), "en");
+		String targetFile = tmpDir.resolve("output.properties").toString();
+		manager.store(targetFile);
+
+		assertTrue(Files.exists(Path.of(targetFile)));
+		String stored = Files.readString(Path.of(targetFile));
+		assertTrue(stored.contains("greeting=Hello"));
+	}
+
+	@Test
+	void newBundleManagerHasEmptyBundle() {
+		assertTrue(manager.getBundle().getItems().findAny().isEmpty());
+		assertNull(manager.getBundle().getFirstLanguage());
+	}
+}

--- a/src/test/java/org/zaval/tools/i18n/translator/BundleSetTest.java
+++ b/src/test/java/org/zaval/tools/i18n/translator/BundleSetTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2001-2002  Zaval Creative Engineering Group (http://www.zaval.org)
+ * Copyright (C) 2026 Christoph Obexer <cobexer@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * (version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.zaval.tools.i18n.translator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BundleSetTest {
+	private BundleSet set;
+
+	@BeforeEach
+	void setUp() {
+		set = new BundleSet();
+	}
+
+	@Test
+	void newSetHasNoLanguages() {
+		assertFalse(set.hasLanguages());
+		assertEquals(0, set.getLanguageCount());
+	}
+
+	@Test
+	void addLanguageCreatesEntry() {
+		set.addLanguage("en");
+		assertTrue(set.hasLanguages());
+		assertEquals(1, set.getLanguageCount());
+		assertNotNull(set.getLanguage("en"));
+	}
+
+	@Test
+	void addLanguageTwiceIsIdempotent() {
+		set.addLanguage("en");
+		set.addLanguage("en");
+		assertEquals(1, set.getLanguageCount());
+	}
+
+	@Test
+	void addLanguageSetsLocaleDescription() {
+		set.addLanguage("de");
+		LangItem lang = set.getLanguage("de");
+		assertNotNull(lang);
+		assertEquals("de", lang.getId());
+		assertTrue(lang.getDescription().toLowerCase().contains("german") || lang.getDescription().toLowerCase().contains("deutsch"));
+	}
+
+	@Test
+	void addLanguageWithCountrySetsCompoundDescription() {
+		set.addLanguage("de_DE");
+		LangItem lang = set.getLanguage("de_DE");
+		assertNotNull(lang);
+		assertTrue(lang.getDescription().contains("("));
+	}
+
+	@Test
+	void getFirstLanguageReturnsNullWhenEmpty() {
+		assertNull(set.getFirstLanguage());
+	}
+
+	@Test
+	void getFirstLanguageReturnsFirstAdded() {
+		set.addLanguage("en");
+		set.addLanguage("de");
+		assertEquals("en", set.getFirstLanguage().getId());
+	}
+
+	@Test
+	void getLanguagesReturnsAllAdded() {
+		set.addLanguage("en");
+		set.addLanguage("fr");
+		LangItem[] langs = set.getLanguages();
+		assertEquals(2, langs.length);
+	}
+
+	@Test
+	void getLanguageIndexReturnsMinusOneForMissing() {
+		set.addLanguage("en");
+		assertEquals(-1, set.getLanguageIndex("de"));
+	}
+
+	@Test
+	void getLanguageIndexForFirstLanguageIsZero() {
+		set.addLanguage("en");
+		assertEquals(0, set.getLanguageIndex("en"));
+	}
+
+	@Test
+	void addKeyCreatesItem() {
+		BundleItem item = set.addKey("app.title");
+		assertNotNull(item);
+		assertEquals("app.title", item.getId());
+		assertEquals(1, set.getItemCount());
+	}
+
+	@Test
+	void addKeyIsIdempotent() {
+		BundleItem first = set.addKey("app.title");
+		BundleItem second = set.addKey("app.title");
+		assertEquals(first, second);
+		assertEquals(1, set.getItemCount());
+	}
+
+	@Test
+	void getItemReturnsNullForMissingKey() {
+		assertNull(set.getItem("missing"));
+	}
+
+	@Test
+	void getItemReturnsAddedKey() {
+		set.addKey("key1");
+		assertNotNull(set.getItem("key1"));
+	}
+
+	@Test
+	void removeKeyDeletesItem() {
+		set.addKey("key1");
+		set.removeKey("key1");
+		assertNull(set.getItem("key1"));
+		assertEquals(0, set.getItemCount());
+	}
+
+	@Test
+	void getItemsStreamCoversAllKeys() {
+		set.addKey("b");
+		set.addKey("a");
+		List<String> ids = set.getItems().map(BundleItem::getId).collect(Collectors.toList());
+		assertEquals(2, ids.size());
+		assertTrue(ids.contains("a"));
+		assertTrue(ids.contains("b"));
+	}
+
+	@Test
+	void getKeysBeginningWithFiltersCorrectly() {
+		set.addKey("app.title");
+		set.addKey("app.cancel");
+		set.addKey("menu.file");
+		List<BundleItem> appKeys = set.getKeysBeginningWith("app.").collect(Collectors.toList());
+		assertEquals(2, appKeys.size());
+	}
+
+	@Test
+	void removeKeysBeginningWithRemovesMatchingKeys() {
+		set.addKey("app.title");
+		set.addKey("app.cancel");
+		set.addKey("menu.file");
+		set.removeKeysBeginningWith("app.");
+		assertNull(set.getItem("app.title"));
+		assertNull(set.getItem("app.cancel"));
+		assertNotNull(set.getItem("menu.file"));
+	}
+
+	@Test
+	void updateValueSetsTranslationOnExistingItem() {
+		set.addKey("key1");
+		set.addLanguage("en");
+		set.updateValue("key1", "en", "Hello");
+		assertEquals("Hello", set.getItem("key1").getTranslation("en"));
+	}
+
+	@Test
+	void updateValueDoesNothingForMissingKey() {
+		set.updateValue("missing", "en", "value");
+	}
+
+	@Test
+	void storeProducesKeyValueLines() {
+		set.addLanguage("en");
+		BundleItem item = set.addKey("greeting");
+		item.setTranslation("en", "Hello");
+		List<String> lines = set.store("en");
+		assertTrue(lines.contains("greeting=Hello"));
+	}
+
+	@Test
+	void storeSkipsItemsWithNullTranslation() {
+		set.addLanguage("en");
+		set.addLanguage("de");
+		BundleItem item = set.addKey("greeting");
+		item.setTranslation("en", "Hello");
+		List<String> lines = set.store("de");
+		assertTrue(lines.isEmpty());
+	}
+
+	@Test
+	void storeIncludesCommentBeforeKey() {
+		set.addLanguage("en");
+		BundleItem item = set.addKey("key1");
+		item.setComment("a comment");
+		item.setTranslation("en", "value");
+		List<String> lines = set.store("en");
+		int commentIdx = lines.indexOf("#a comment");
+		int valueIdx = lines.indexOf("key1=value");
+		assertTrue(commentIdx >= 0);
+		assertTrue(valueIdx >= 0);
+		assertTrue(commentIdx < valueIdx);
+	}
+}

--- a/src/test/java/org/zaval/tools/i18n/translator/LangItemTest.java
+++ b/src/test/java/org/zaval/tools/i18n/translator/LangItemTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2001-2002  Zaval Creative Engineering Group (http://www.zaval.org)
+ * Copyright (C) 2026 Christoph Obexer <cobexer@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * (version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.zaval.tools.i18n.translator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class LangItemTest {
+	@Test
+	void constructorSetsIdAndDescription() {
+		LangItem item = new LangItem("de", "German");
+		assertEquals("de", item.getId());
+		assertEquals("German", item.getDescription());
+	}
+
+	@Test
+	void fileNameIsNullByDefault() {
+		LangItem item = new LangItem("en", "English");
+		assertNull(item.getFileName());
+	}
+
+	@Test
+	void setAndGetFileName() {
+		LangItem item = new LangItem("en", "English");
+		item.setFileName("messages_en.properties");
+		assertEquals("messages_en.properties", item.getFileName());
+	}
+
+	@Test
+	void setFileNameOverwritesPreviousValue() {
+		LangItem item = new LangItem("en", "English");
+		item.setFileName("old.properties");
+		item.setFileName("new.properties");
+		assertEquals("new.properties", item.getFileName());
+	}
+}

--- a/src/test/java/org/zaval/tools/i18n/translator/SrcGeneratorTest.java
+++ b/src/test/java/org/zaval/tools/i18n/translator/SrcGeneratorTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2001-2002  Zaval Creative Engineering Group (http://www.zaval.org)
+ * Copyright (C) 2026 Christoph Obexer <cobexer@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * (version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.zaval.tools.i18n.translator;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SrcGeneratorTest {
+	@Test
+	void performGeneratesClassWithKeyMethods(@TempDir Path tmpDir) throws IOException {
+		Path outFile = tmpDir.resolve("MyBundle.java");
+		BundleSet set = new BundleSet();
+		set.addLanguage("en");
+		set.addKey("app.title").setTranslation("en", "Title");
+		set.addKey("app.cancel").setTranslation("en", "Cancel");
+
+		new SrcGenerator(outFile.toString()).perform(set);
+
+		String src = Files.readString(outFile);
+		assertTrue(src.contains("class MyBundle"));
+		assertTrue(src.contains("getAppTitle"));
+		assertTrue(src.contains("setAppTitle"));
+		assertTrue(src.contains("getAppCancel"));
+		assertTrue(src.contains("setAppCancel"));
+	}
+
+	@Test
+	void performGeneratesLoadFromResourceMethod(@TempDir Path tmpDir) throws IOException {
+		Path outFile = tmpDir.resolve("Res.java");
+		BundleSet set = new BundleSet();
+		set.addLanguage("en");
+		set.addKey("label").setTranslation("en", "Label");
+
+		new SrcGenerator(outFile.toString()).perform(set);
+
+		String src = Files.readString(outFile);
+		assertTrue(src.contains("loadFromResource"));
+		assertTrue(src.contains("ResourceBundle"));
+	}
+
+	@Test
+	void performHandlesTopLevelKeyWithNoDots(@TempDir Path tmpDir) throws IOException {
+		Path outFile = tmpDir.resolve("Simple.java");
+		BundleSet set = new BundleSet();
+		set.addLanguage("en");
+		set.addKey("title").setTranslation("en", "My App");
+
+		new SrcGenerator(outFile.toString()).perform(set);
+
+		String src = Files.readString(outFile);
+		assertTrue(src.contains("getTitle"));
+		assertTrue(src.contains("setTitle"));
+	}
+}

--- a/src/test/java/org/zaval/util/LambdaUtilsTest.java
+++ b/src/test/java/org/zaval/util/LambdaUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2001-2002  Zaval Creative Engineering Group (http://www.zaval.org)
+ * Copyright (C) 2026 Christoph Obexer <cobexer@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * (version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.zaval.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+class LambdaUtilsTest {
+	@Test
+	void uncheckedSupplierReturnsValue() {
+		Supplier<String> supplier = LambdaUtils.unchecked(() -> "hello");
+		assertEquals("hello", supplier.get());
+	}
+
+	@Test
+	void uncheckedSupplierPropagatesCheckedException() {
+		Supplier<String> supplier = LambdaUtils.unchecked(() -> {
+			throw new IOException("test error");
+		});
+		assertThrows(IOException.class, supplier::get);
+	}
+
+	@Test
+	void uncheckedConsumerRunsSuccessfully() {
+		int[] counter = { 0 };
+		Consumer<String> consumer = LambdaUtils.unchecked(s -> counter[0]++);
+		consumer.accept("anything");
+		assertEquals(1, counter[0]);
+	}
+
+	@Test
+	void uncheckedConsumerPropagatesCheckedException() {
+		Consumer<String> consumer = LambdaUtils.unchecked(s -> {
+			throw new IOException("consumer error");
+		});
+		assertThrows(IOException.class, () -> consumer.accept("input"));
+	}
+
+	@Test
+	void uncheckedSupplierWithRuntimeExceptionPropagatesDirectly() {
+		Supplier<String> supplier = LambdaUtils.unchecked(() -> {
+			throw new IllegalStateException("runtime");
+		});
+		assertThrows(IllegalStateException.class, supplier::get);
+	}
+}

--- a/src/test/java/org/zaval/util/SafeResourceBundleTest.java
+++ b/src/test/java/org/zaval/util/SafeResourceBundleTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2001-2002  Zaval Creative Engineering Group (http://www.zaval.org)
+ * Copyright (C) 2026 Christoph Obexer <cobexer@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * (version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.zaval.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+class SafeResourceBundleTest {
+	private static final String FAILURE_STRING = "?????";
+
+	@Test
+	void getStringReturnsFallbackForMissingBundle() {
+		SafeResourceBundle bundle = new SafeResourceBundle("nonexistent.resource.bundle", null);
+		assertEquals(FAILURE_STRING, bundle.getString("any.key"));
+	}
+
+	@Test
+	void getStringReturnsFallbackForMissingKey() {
+		SafeResourceBundle bundle = new SafeResourceBundle("jrc-editor", Locale.ENGLISH);
+		assertEquals(FAILURE_STRING, bundle.getString("this.key.does.not.exist"));
+	}
+
+	@Test
+	void getStringReturnsValueForExistingKey() {
+		SafeResourceBundle bundle = new SafeResourceBundle("jrc-editor", Locale.ROOT);
+		String value = bundle.getString("dialog.button.cancel");
+		assertEquals("Cancel", value);
+	}
+
+	@Test
+	void nullLocaleReturnsNonFallbackValueForExistingKey() {
+		SafeResourceBundle bundle = new SafeResourceBundle("jrc-editor", null);
+		String value = bundle.getString("dialog.button.cancel");
+		assertFalse(FAILURE_STRING.equals(value), "Expected a real translation, not the failure string");
+	}
+}

--- a/src/test/java/org/zaval/xml/XmlElementTest.java
+++ b/src/test/java/org/zaval/xml/XmlElementTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2001-2002  Zaval Creative Engineering Group (http://www.zaval.org)
+ * Copyright (C) 2026 Christoph Obexer <cobexer@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * (version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.zaval.xml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.junit.jupiter.api.Test;
+
+class XmlElementTest {
+	private XmlElement parse(String xml) throws IOException, XmlParseException {
+		XmlElement el = new XmlElement();
+		el.parse(new StringReader(xml));
+		return el;
+	}
+
+	@Test
+	void parseSimpleElement() throws Exception {
+		XmlElement el = parse("<root/>");
+		assertEquals("root", el.getName());
+	}
+
+	@Test
+	void parseElementWithContent() throws Exception {
+		XmlElement el = parse("<message>Hello World</message>");
+		assertEquals("message", el.getName());
+		assertEquals("Hello World", el.getContent());
+	}
+
+	@Test
+	void parseAttribute() throws Exception {
+		XmlElement el = parse("<item name=\"foo\"/>");
+		assertEquals("foo", el.getAttribute("name"));
+	}
+
+	@Test
+	void attributeNamesAreLowercased() throws Exception {
+		XmlElement el = parse("<item Name=\"bar\"/>");
+		assertEquals("bar", el.getAttribute("name"));
+	}
+
+	@Test
+	void parseChildElements() throws Exception {
+		XmlElement el = parse("<root><child1/><child2/></root>");
+		assertEquals(2, el.children().size());
+		assertEquals("child1", el.children().get(0).getName());
+		assertEquals("child2", el.children().get(1).getName());
+	}
+
+	@Test
+	void parseCdataSection() throws Exception {
+		XmlElement el = parse("<root><![CDATA[<not-a-tag>]]></root>");
+		assertTrue(el.getContent().contains("<not-a-tag>"));
+	}
+
+	@Test
+	void parseEntityReferences() throws Exception {
+		XmlElement el = parse("<root>&amp;&lt;&gt;&quot;&apos;</root>");
+		assertEquals("&<>\"'", el.getContent());
+	}
+
+	@Test
+	void parseNumericCharacterReference() throws Exception {
+		XmlElement el = parse("<root>&#65;</root>");
+		assertEquals("A", el.getContent());
+	}
+
+	@Test
+	void parseHexCharacterReference() throws Exception {
+		XmlElement el = parse("<root>&#x41;</root>");
+		assertEquals("A", el.getContent());
+	}
+
+	@Test
+	void parseXmlDeclarationIsSkipped() throws Exception {
+		XmlElement el = parse("<?xml version=\"1.0\"?><root/>");
+		assertEquals("root", el.getName());
+	}
+
+	@Test
+	void malformedXmlThrowsXmlParseException() {
+		assertThrows(XmlParseException.class, () -> parse("<unclosed"));
+	}
+
+	@Test
+	void unknownEntityThrowsXmlParseException() {
+		assertThrows(XmlParseException.class, () -> parse("<root>&unknown;</root>"));
+	}
+
+	@Test
+	void toStringProducesXml() throws Exception {
+		XmlElement el = parse("<item key=\"k\">value</item>");
+		String result = el.toString();
+		assertNotNull(result);
+		assertTrue(result.contains("item"));
+		assertTrue(result.contains("value"));
+	}
+
+	@Test
+	void parseMultipleAttributesOnElement() throws Exception {
+		XmlElement el = parse("<entry lang=\"en\" name=\"greeting\">Hello</entry>");
+		assertEquals("en", el.getAttribute("lang"));
+		assertEquals("greeting", el.getAttribute("name"));
+		assertEquals("Hello", el.getContent());
+	}
+}

--- a/src/test/java/org/zaval/xml/XmlReaderTest.java
+++ b/src/test/java/org/zaval/xml/XmlReaderTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2001-2002  Zaval Creative Engineering Group (http://www.zaval.org)
+ * Copyright (C) 2026 Christoph Obexer <cobexer@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * (version 2) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package org.zaval.xml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class XmlReaderTest {
+	@Test
+	void flattenSingleChildWithNameAttribute() throws Exception {
+		String xml = "<resources><entry name=\"greeting\">Hello</entry></resources>";
+		Map<String, String> map = new XmlReader(xml).flatten();
+		assertEquals("Hello", map.get("greeting"));
+	}
+
+	@Test
+	void flattenMultipleChildren() throws Exception {
+		String xml = "<resources>" + "<entry name=\"a\">Alpha</entry>" + "<entry name=\"b\">Beta</entry>" + "</resources>";
+		Map<String, String> map = new XmlReader(xml).flatten();
+		assertEquals("Alpha", map.get("a"));
+		assertEquals("Beta", map.get("b"));
+	}
+
+	@Test
+	void flattenUsesLangAttributeOverName() throws Exception {
+		String xml = "<resources><entry lang=\"en\" name=\"greeting\">Hello</entry></resources>";
+		Map<String, String> map = new XmlReader(xml).flatten();
+		assertTrue(map.containsKey("en"));
+		assertFalse(map.containsKey("greeting"));
+	}
+
+	@Test
+	void flattenNestedChildrenBuildsDottedPath() throws Exception {
+		String xml = "<root><group name=\"app\"><entry name=\"title\">My App</entry></group></root>";
+		Map<String, String> map = new XmlReader(xml).flatten();
+		assertTrue(map.containsKey("app!title") || map.containsKey("app"));
+	}
+
+	@Test
+	void flattenEmptyRootReturnsEmptyMap() throws Exception {
+		Map<String, String> map = new XmlReader("<root/>").flatten();
+		assertTrue(map.isEmpty());
+	}
+
+	@Test
+	void flattenFallsBackToElementNameWhenNoLangOrName() throws Exception {
+		String xml = "<resources><item>Value</item></resources>";
+		Map<String, String> map = new XmlReader(xml).flatten();
+		assertEquals("Value", map.get("item"));
+	}
+}


### PR DESCRIPTION
## Summary
- Add JUnit 5 test infrastructure to the Gradle build and refresh the Gradle wrapper
- Add 84 unit tests covering core classes: `BundleItem`, `BundleManager`, `BundleSet`, `LangItem`, `SrcGenerator`, `LambdaUtils`, `SafeResourceBundle`, `XmlElement`, `XmlReader`
- Track follow-up test coverage work in `TODO.md`

## Test plan
- [x] `./gradlew test` passes locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source generation to correctly handle both Unix- and Windows-style file paths.

* **Tests**
  * Added comprehensive automated coverage for translation bundles, language management, source generation, utility functions, resource fallback, and XML parsing.
  * Added validation for translation lookup, file handling, comments, empty values, nested XML structures, entities, malformed input, and serialization.

* **Chores**
  * Added JUnit 5 and Mockito test tooling.
  * Configured tests to run on the JUnit Platform and the build daemon to use Java 21.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->