### PR TITLE
ci: remove Scrutinizer integration

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,0 @@
-build:
-  nodes:
-    analysis:
-      tests:
-        override:
-          - java-scrutinizer-run
-


### PR DESCRIPTION
## Summary

Scrutinizer has been red on master and every PR for months (`Analysis: Errored – Tests: failed`). Removing `.scrutinizer.yml` to stop the persistent red status. See findings below.

## Why

- `java-scrutinizer-run` is effectively unmaintained. The scrutinizer-ci org's core analyzer repos were last pushed in **2021–2022** and the main `scrutinizer` repo is **archived**. No public `.scrutinizer.yml` targeting `java-scrutinizer-run` pins a JDK newer than 8.
- Sister project **fullsync/fullsync**, which pins Java 17 via SDKMAN and runs `./gradlew test jacocoRootReport` explicitly, is **also red** on Scrutinizer today — so even the "correct" pattern doesn't turn green on modern JDKs.
- The failure predates the recent test-infrastructure work; inspection history shows red going back to at least **May 22, 2026** with the same signature.
- **SonarCloud** already covers static analysis on every PR; the **GitHub Actions matrix** (ubuntu/macOS/windows-latest) covers tests. Scrutinizer is redundant coverage on top of tools that actually work with our stack.

## Follow-up (manual, cross-repo)

The GitHub webhook is still linked at [scrutinizer-ci.com/dashboard](https://scrutinizer-ci.com/dashboard). Without the config file, Scrutinizer will keep receiving push events; unlink the repo there to stop future status posts entirely.

## Test plan

- [x] `./gradlew build` passes locally with `.scrutinizer.yml` removed
- [ ] GH Actions matrix (ubuntu/macOS/windows) stays green on this PR
- [ ] SonarCloud check stays green on this PR
- [ ] After merge: verify Scrutinizer no longer posts a check on subsequent PRs (or unlink the webhook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build analysis configuration by removing an outdated Java test override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->